### PR TITLE
subscribe to client requests so they will be executed

### DIFF
--- a/test/golden/with_setup/angular.ts
+++ b/test/golden/with_setup/angular.ts
@@ -25,7 +25,7 @@ export class WidgetComponent {
         type: KalturaSessionType.admin,
         partnerId: YOUR_PARTNER_ID,
     }))
-	.map(ks => {
+	.subscribe(ks => {
 		  this.kaltura.setDefaultRequestOptions({ks});
           this.runRequest();
 		},
@@ -40,7 +40,7 @@ export class WidgetComponent {
     let pager = new KalturaFilterPager();
 
     this.kaltura.request(new MediaListAction({filter, pager}))
-        .map(result => {
+        .subscribe(result => {
           console.log(result);
         },
         error => {


### PR DESCRIPTION
Observables are [cold by default](https://alligator.io/rxjs/hot-cold-observables/) which means that they will not be executed unless you `subscribe` to them.

using `map` is used if you want to manipulate the result value but it doesn't replace the `subscribe`. When you set it you just instruct the pipe what to do once it gets a value. So to fix your code you must call `subscribe()` but once you do that you don't need `map` anymore.

relates to #50 