### PR TITLE
skip full prerender on most commits

### DIFF
--- a/scripts/build-and-commit.sh
+++ b/scripts/build-and-commit.sh
@@ -7,9 +7,13 @@ mkdir ./markdown/generated
 
 echo "Building OVP Website..."
 git clone https://github.com/kaltura/developer-platform-generated generated/ovp
-rm -rf generated/ovp/*
+full_prerender=0
+if [ "$(git log -1 --pretty=format:'%an %s')" == *"[full build]"* ]; then
+  rm -rf generated/ovp/*
+  full_prerender=1
+fi
 TARGET_API=ovp ./scripts/resources/all.sh
-TARGET_API=ovp lucybot build --prerender --destination generated/ovp
+TARGET_API=ovp FULL_PRERENDER=$full_prerender lucybot build --prerender --destination generated/ovp
 
 cd generated/ovp
 git pull

--- a/v4-navigation.js
+++ b/v4-navigation.js
@@ -1,6 +1,7 @@
 const TARGET_API = process.env.TARGET_API || 'ovp';
 const openapi = require('./' + TARGET_API + '.openapi.json');
 const fs = require('fs');
+const FULL_PRERENDER = process.env.FULL_PRERENDER === "1";
 
 function getOperations(tag) {
   let ops = [];
@@ -22,6 +23,7 @@ module.exports = function(config) {
   function setPathForItem(item, oldPath='') {
     let nextPath = oldPath;
     if (item.tag) {
+      item.prerender = FULL_PRERENDER;
       nextPath += '/' + item.tag;
       item.path = '/service/' + item.tag;
       addRedirect(nextPath, item.path);
@@ -31,6 +33,7 @@ module.exports = function(config) {
         })
       }
     } else if (item.operation) {
+      item.prerender = FULL_PRERENDER;
       nextPath += '/' + item.operation.replace(/\W+/g, '_');
       let [service, action] = item.operation.split('.');
       item.path = '/service/' + service + '/action/' + action;


### PR DESCRIPTION
This change alters the build pipeline.

For most commits, it will simply rebuild the most commonly-edited pages. Pages for API operations and objects will not be rebuilt. This should result in a much faster build when making trivial changes.

If a significant change is made (e.g. API spec changes, site-wide CSS changes, or an update to LucyBot), we can make a commit containing the string `[full build]`, which will trigger a full rebuild of the website.

I've tested this works by running:
```
TARGET_API=ovp FULL_PRERENDER=1 lucybot build --prerender --destination generated/ovp
```
making a trivial change to client_libraries.md, and then running:
```
TARGET_API=ovp FULL_PRERENDER=0 lucybot build --prerender --destination generated/ovp
```
On my machine, the first build took 20m, the second took 4.5m